### PR TITLE
Alpine latest doesn't contain telnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Catch all mail and display it in roundcube interface.
 
 ## Send email
 
-    $ docker run -it --link mailtrap alpine sh
+    $ docker run -it --link mailtrap alpine:3.6 sh
 
       $ telnet mailtrap 25
       ehlo example.com


### PR DESCRIPTION
Issue: `Alpine:latest` appears to no longer contain `telnet`. 
Fix: `Alpine:3.6` does contain telnet.

By pinning the tag used in the example we can ensure that users can run the example in the future.

https://github.com/gliderlabs/docker-alpine/issues/397